### PR TITLE
fix: pinned icon alignment is off

### DIFF
--- a/src/menu/menu.scss
+++ b/src/menu/menu.scss
@@ -32,7 +32,7 @@
       left: 14px;
       width: 17px;
       height: 17px;
-      top: 6px;
+      top: 7px;
       cursor: pointer;
 
       path {
@@ -70,7 +70,7 @@
         cursor: default
       }
 
-      svg.pin {
+      svg.unpin {
         top: 4px;
         cursor: pointer;
       }


### PR DESCRIPTION
fix css selector that was causing misalignment
